### PR TITLE
fix: avoid using `saveState` to detect unclean buildkitd shutdown

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -676,6 +676,7 @@ void actionsToolkit.run(
       let cleanupError: Error | null = null;
       let fsDiskUsageBytes: number | null = null;
       let integrityCheckPassed: boolean | null = null;
+      let buildkitdShutdownCleanly: boolean | null = null;
 
       try {
         // Step 1: Check if buildkitd is running and shut it down
@@ -700,18 +701,22 @@ void actionsToolkit.run(
 
             // Critical: Shutdown buildkitd
             const buildkitdShutdownStartTime = Date.now();
-            await shutdownBuildkitd();
+            buildkitdShutdownCleanly = await shutdownBuildkitd();
             const buildkitdShutdownDurationMs =
               Date.now() - buildkitdShutdownStartTime;
             await reporter.reportMetric(
               Metric_MetricType.BPA_BUILDKITD_SHUTDOWN_DURATION_MS,
               buildkitdShutdownDurationMs,
             );
-            core.info("Shutdown buildkitd gracefully");
+            core.info(
+              `Shutdown buildkitd ${buildkitdShutdownCleanly ? "gracefully" : "forcefully"}`,
+            );
           } else {
             // Check if buildkitd was expected to be running (we have state indicating it was started)
             const buildkitdAddr = stateHelper.getBuildkitdAddr();
             if (buildkitdAddr) {
+              buildkitdShutdownCleanly = false;
+
               core.warning(
                 "buildkitd process has crashed - process not found but was expected to be running",
               );
@@ -729,6 +734,8 @@ void actionsToolkit.run(
                 );
               }
             } else {
+              buildkitdShutdownCleanly = true;
+
               core.debug(
                 "No buildkitd process found running and none was expected",
               );
@@ -745,6 +752,8 @@ void actionsToolkit.run(
           // Check if buildkitd was expected to be running (we have state indicating it was started)
           const buildkitdAddr = stateHelper.getBuildkitdAddr();
           if (buildkitdAddr) {
+            buildkitdShutdownCleanly = false;
+
             core.warning(
               "buildkitd process has crashed - pgrep failed but buildkitd was expected to be running",
             );
@@ -762,6 +771,8 @@ void actionsToolkit.run(
               );
             }
           } else {
+            buildkitdShutdownCleanly = true;
+
             core.debug(
               "No buildkitd process found (pgrep returned 1) and none was expected",
             );
@@ -932,9 +943,9 @@ void actionsToolkit.run(
             core.warning(
               "Skipping sticky disk commit due to previous step failures",
             );
-          } else if (stateHelper.getSigkillUsed()) {
+          } else if (!buildkitdShutdownCleanly) {
             core.warning(
-              "Skipping sticky disk commit because SIGKILL was used to terminate buildkitd - disk may be in a bad state",
+              "Skipping sticky disk commit because buildkitd did not shut down cleanly - disk may be in a bad state",
             );
           } else {
             // No failures detected and cleanup was successful

--- a/src/shutdown.ts
+++ b/src/shutdown.ts
@@ -1,11 +1,10 @@
 import * as core from "@actions/core";
 import { promisify } from "util";
 import { exec } from "child_process";
-import * as stateHelper from "./state-helper";
 
 const execAsync = promisify(exec);
 
-export async function shutdownBuildkitd(): Promise<void> {
+export async function shutdownBuildkitd(): Promise<boolean> {
   const gracefulTimeout = 30000; // 30 seconds for graceful shutdown.
   const forceTimeout = 5000; // 5 seconds for forced shutdown.
   const backoff = 300; // 300ms.
@@ -28,7 +27,7 @@ export async function shutdownBuildkitd(): Promise<void> {
         if ((error as { code?: number }).code === 1) {
           // pgrep returns exit code 1 when no process is found, which means shutdown successful.
           core.info("buildkitd successfully shutdown gracefully");
-          return;
+          return true;
         }
         // Some other error occurred.
         throw error;
@@ -42,7 +41,6 @@ export async function shutdownBuildkitd(): Promise<void> {
     core.warning(
       "Disk may be in a bad state after SIGKILL - will prevent sticky disk commit",
     );
-    stateHelper.setSigkillUsed(true);
     await execAsync(`sudo pkill -KILL buildkitd`);
 
     // Wait for forced shutdown.
@@ -58,7 +56,7 @@ export async function shutdownBuildkitd(): Promise<void> {
         if ((error as { code?: number }).code === 1) {
           // Process is gone.
           core.warning("buildkitd was forcefully terminated with SIGKILL");
-          return;
+          return false;
         }
         // Some other error occurred.
         throw error;

--- a/src/state-helper.ts
+++ b/src/state-helper.ts
@@ -37,11 +37,3 @@ export function setBuilderName(name: string) {
 export function getBuilderName(): string {
   return core.getState("builderName");
 }
-
-export function setSigkillUsed(used: boolean) {
-  core.saveState("sigkillUsed", used.toString());
-}
-
-export function getSigkillUsed(): boolean {
-  return core.getState("sigkillUsed") === "true";
-}


### PR DESCRIPTION
Fixes https://github.com/useblacksmith/setup-docker-builder/issues/68

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes cleanup decision logic that gates sticky-disk commits; incorrect shutdown classification could skip commits or commit after a bad shutdown.
> 
> **Overview**
> Cleanup now treats `shutdownBuildkitd()` as returning whether shutdown was **graceful vs forced**, and logs the outcome accordingly.
> 
> Sticky-disk commit gating is updated to skip commits whenever BuildKit *did not shut down cleanly* (including crashes/missing process), and the old `sigkillUsed` state flag is removed from `state-helper`/shutdown flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a0caadadfcc042e17c061fa9229e7e95071e0f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->