### PR TITLE
ci: add update-dist workflow to auto-rebuild dist on push

### DIFF
--- a/.github/workflows/update-dist.yml
+++ b/.github/workflows/update-dist.yml
@@ -4,11 +4,16 @@ on:
   push:
     branches-ignore:
       - main
+      - master
     paths:
       - "src/**"
       - "package.json"
       - "pnpm-lock.yaml"
       - "tsconfig.json"
+
+concurrency:
+  group: update-dist-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: write
@@ -18,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
 
       - uses: actions/setup-node@v4
         with:
@@ -58,4 +65,5 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add dist/
           git commit -m "chore: rebuild dist"
+          git pull --rebase
           git push

--- a/.github/workflows/update-dist.yml
+++ b/.github/workflows/update-dist.yml
@@ -1,0 +1,61 @@
+name: Update dist
+
+on:
+  push:
+    branches-ignore:
+      - main
+    paths:
+      - "src/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "tsconfig.json"
+
+permissions:
+  contents: write
+
+jobs:
+  update-dist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 8.15.9
+
+      - uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ github.token }}
+
+      - name: Configure npm for buf registry
+        env:
+          BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
+        run: |
+          npm config set @buf:registry https://buf.build/gen/npm/v1/
+          npm config set //buf.build/gen/npm/v1/:_authToken $BUF_TOKEN
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Check for dist changes
+        id: diff
+        run: |
+          if [[ -n "$(git status --porcelain dist/)" ]]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit and push updated dist
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add dist/
+          git commit -m "chore: rebuild dist"
+          git push


### PR DESCRIPTION
The repo has `build.yml` and `verify-build.yml` that detect when `dist/` is stale, but neither actually rebuilds and commits it. This means every contributor (internal or external) has to remember to run `pnpm run build` locally and commit the result — and external contributors can't even do that because `pnpm install` requires `BUF_TOKEN` for the private Buf registry packages.

This adds a new `update-dist.yml` workflow that triggers on pushes to non-main branches whenever source files change (`src/**`, `package.json`, `pnpm-lock.yaml`, `tsconfig.json`). It installs deps with `BUF_TOKEN`, runs `pnpm run build`, and if `dist/` changed, auto-commits and pushes the update. The `paths` filter deliberately excludes `dist/` so the bot's own commit never re-triggers the workflow.

This only covers branches pushed directly to this repo (internal PRs). Fork PRs still can't auto-rebuild because `GITHUB_TOKEN` can't push to a fork's branch — for those, the current workflow is to cherry-pick onto an internal branch first. Adding full fork support would require a PAT or GitHub App token, which can be done as a follow-up if needed.

---
[View Codesmith session](https://staging.blacksmith.sh/useblacksmith/sessions/019d25e6-dd7e-7316-8686-d6c4ad8a5256)