### PR TITLE
Update action runtime from node20 to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,6 @@ inputs:
     description: "Maximum number of concurrent BuildKit RUN steps. Defaults to the number of vCPUs on the runner."
     required: false
 runs:
-  using: node20
+  using: node24
   main: dist/index.js
   post: dist/index.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@eslint/js": "^9.29.0",
         "@rollup/plugin-node-resolve": "^16.0.1",
         "@rollup/plugin-typescript": "^12.1.4",
-        "@tsconfig/node20": "^20.1.6",
+        "@tsconfig/node24": "^24.0.0",
         "@types/iarna__toml": "^2.0.5",
         "@types/node": "^24.1.0",
         "@vercel/ncc": "^0.38.3",
@@ -2242,10 +2242,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@tsconfig/node20": {
-      "version": "20.1.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.9.tgz",
-      "integrity": "sha512-IjlTv1RsvnPtUcjTqtVsZExKVq+KQx4g5pCP5tI7rAs6Xesl2qFwSz/tPDBC4JajkL/MlezBu3gPUwqRHl+RIg==",
+    "node_modules/@tsconfig/node24": {
+      "version": "24.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node24/-/node24-24.0.4.tgz",
+      "integrity": "sha512-2A933l5P5oCbv6qSxHs7ckKwobs8BDAe9SJ/Xr2Hy+nDlwmLE1GhFh/g/vXGRZWgxBg9nX/5piDtHR9Dkw/XuA==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@eslint/js": "^9.29.0",
     "@rollup/plugin-node-resolve": "^16.0.1",
     "@rollup/plugin-typescript": "^12.1.4",
-    "@tsconfig/node20": "^20.1.6",
+    "@tsconfig/node24": "^24.0.0",
     "@types/iarna__toml": "^2.0.5",
     "@types/node": "^24.1.0",
     "@vercel/ncc": "^0.38.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,9 +48,9 @@ importers:
       '@rollup/plugin-typescript':
         specifier: ^12.1.4
         version: 12.1.4(rollup@4.46.2)(typescript@5.9.2)
-      '@tsconfig/node20':
-        specifier: ^20.1.6
-        version: 20.1.6
+      '@tsconfig/node24':
+        specifier: ^24.0.0
+        version: 24.0.4
       '@types/iarna__toml':
         specifier: ^2.0.5
         version: 2.0.5
@@ -1359,8 +1359,8 @@ packages:
     engines: {node: '>=18'}
     dev: false
 
-  /@tsconfig/node20@20.1.6:
-    resolution: {integrity: sha512-sz+Hqx9zwZDpZIV871WSbUzSqNIsXzghZydypnfgzPKLltVJfkINfUeTct31n/tTSa9ZE1ZOfKdRre1uHHquYQ==}
+  /@tsconfig/node24@24.0.4:
+    resolution: {integrity: sha512-2A933l5P5oCbv6qSxHs7ckKwobs8BDAe9SJ/Xr2Hy+nDlwmLE1GhFh/g/vXGRZWgxBg9nX/5piDtHR9Dkw/XuA==}
     dev: true
 
   /@types/chai@5.2.2:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node20",
+  "extends": "@tsconfig/node24",
   "compilerOptions": {
     "module": "ESNext",
     "moduleResolution": "bundler",


### PR DESCRIPTION
GitHub is [deprecating Node 20 on Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). This PR migrates the action runtime from `node20` to `node24`.

How it works: `action.yml` switches from `node20` to `node24`, `@tsconfig/node20` is replaced with `@tsconfig/node24` in both `package.json` and `tsconfig.json`, and the lockfiles (`package-lock.json` and `pnpm-lock.yaml`) are updated to match. No source code changes needed — the action uses stable Node APIs that are unchanged across versions.

The `@types/node` was already at `^24.1.0` so no change was needed there.

---
[View Codesmith session](https://staging.blacksmith.sh/useblacksmith/sessions/019d2a29-3e97-7079-bf70-9f20156c274e)