### PR TITLE
ci: add cache-key to test workflows for v2 compatibility

### DIFF
--- a/.github/workflows/step-duration-regression.yml
+++ b/.github/workflows/step-duration-regression.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
   pull_request:
   push:
-    branches: [main]
+    branches: [main, release/v2]
   schedule:
     - cron: "17 6 * * *"
 
@@ -27,6 +27,7 @@ jobs:
       - name: ${{ env.SETUP_STEP_NAME }}
         uses: ./
         with:
+          cache-key: test/step-duration-regression
           buildx-version: v0.23.0
 
       - name: Trivial build

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   pull_request:
   push:
-    branches: [main]
+    branches: [main, release/v2]
 
 jobs:
   test-setup:
@@ -43,6 +43,7 @@ jobs:
       - name: Test Docker Builder Setup
         uses: ./
         with:
+          cache-key: test/setup-docker-builder
           buildx-version: "v0.23.0"
           nofallback: "false"
         continue-on-error: true # Allow failure since we may not have Blacksmith env vars
@@ -97,6 +98,7 @@ jobs:
       - name: Test Docker Builder Setup with Driver Options
         uses: ./
         with:
+          cache-key: test/setup-docker-builder-driver-opts
           buildx-version: "v0.23.0"
           driver-opts: |
             env.TEST_VAR_1=value1


### PR DESCRIPTION
## Summary

Add the required `cache-key` input to `test-action.yml` and `step-duration-regression.yml` so they pass on the `release/v2` branch. Also trigger both workflows on push to `release/v2`.

Without this, the self-test workflows fail because v2's `action.yml` requires `cache-key` but the test steps don't provide it.

Link to Devin session: https://app.devin.ai/sessions/1054a9452e8a49ccb891391e2327a612
Requested by: @piob-io

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/useblacksmith/codesmith/setup-docker-builder/pr/110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784837126&installation_id=59834506&pr_number=110&repository=useblacksmith%2Fsetup-docker-builder&return_to=https%3A%2F%2Fgithub.com%2Fuseblacksmith%2Fsetup-docker-builder%2Fpull%2F110&signature=150e20fe7d568cdd01198b53070e8c96ba87670bed0bd317aabb2dc5bc7475ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- codesmith:footer:staging -->
---
<a href="https://staging.blacksmith.sh/useblacksmith/codesmith/setup-docker-builder/pr/110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://stagingbackend.blacksmith.sh/track/enable-autofix?expires=1784837127&installation_id=57496780&pr_number=110&repository=useblacksmith%2Fsetup-docker-builder&return_to=https%3A%2F%2Fgithub.com%2Fuseblacksmith%2Fsetup-docker-builder%2Fpull%2F110&signature=145483997f1cbd3c31d7e04e40ab8790da9a86adb9c71a7a0693fe538deb525c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled. (Staging)</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer:staging -->